### PR TITLE
Update the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <head>
 
     <meta charset="UTF-8">
-    <title>WarpX documentation</title>
+    <title>WarpX</title>
     <!-- <link rel="icon" href="web_icon.ico" type="image/x-icon"> -->
     <meta http-equiv="content-type" content="text/html; charset=utf-8" />
     <meta name="description" content="" />
@@ -66,16 +66,19 @@
 
     <!-- Banner -->
     <section id="banner">
-      <h2>WarpX documentation</h2>
+      <h2>WarpX</h2>
       <br> <br>
-      <p>Latest version
+      <p>WarpX is an advanced 2D/3D electromagnetic Particle-In-Cell code.
       <ul class="actions">
 	<li>
-	  <a href="https://warpx.readthedocs.io" class="button big">dev</a>
+	  <a href="https://warpx.readthedocs.io" class="button big">documentation</a>
+	</li>
+	<li>
+	  <a href="https://github.com/ECP-WarpX/WarpX" class="button big">source</a>
 	</li>
       </ul>
       <br> <br>
-      <p>Earlier versions
+      <p>Earlier versions of the documentation
       <ul class="actions" id="earlier">
       </ul>
     </section>


### PR DESCRIPTION
Replace the home page
https://ecp-warpx.github.io
by the image below (with a button to access the GitHub repo, which is handy).
<img width="1217" alt="Screen Shot 2020-01-09 at 4 29 55 PM" src="https://user-images.githubusercontent.com/26292713/72115857-48570a80-32fd-11ea-92ba-4ab9b59d6c2b.png">

