### PR TITLE
Docs: Remove Earlier Versions

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,43 +23,6 @@
       <link rel="stylesheet" href="css/style.css" />
       <link rel="stylesheet" href="css/style-xlarge.css" />
     </noscript>
-  <script type="text/javascript">
-    $(document).ready(function(){
-      /* work-around for https://github.com/readthedocs/readthedocs.org/issues/6152
-       * via https://www.npmjs.com/package/cors-anywhere */
-      $.ajaxPrefilter(function(options) {
-        if (options.crossDomain && jQuery.support.cors) {
-          options.url = 'https://cors-anywhere.herokuapp.com/' + options.url;
-        }
-      });
-
-      /* curl https://readthedocs.org/api/v2/project/?slug=warpx | jq '.results[0].id' */
-      var warpx_rtd_id = 496616;
-      /* see https://docs.readthedocs.io/en/stable/api/v2.html#project-versions */
-      $.ajax({
-	 crossDomain: true,
-         url: "https://readthedocs.org/api/v2/project/" + warpx_rtd_id.toString() + "/active_versions/",
-	 //dataType: "jsonp",
-         success: function(data) {
-           $.each(data.versions, function(index, value) {
-           var version_name = value.slug;
-           if(version_name != "latest") {
-             $('ul#earlier').append(
-                 '<li><a href="https://warpx.readthedocs.io/en/' +
-                 version_name +
-                 '" class="button big">' +
-                 version_name +
-                 '</a></li>'
-             );
-           }
-           });
-         },
-	 error: function () {
-            console.error('Error loading the RTD API endpoint');
-         },
-      });
-    });
-  </script>
   </head>
   <body class="landing">
 
@@ -76,10 +39,6 @@
 	<li>
 	  <a href="https://github.com/ECP-WarpX/WarpX" class="button big">source</a>
 	</li>
-      </ul>
-      <br> <br>
-      <p>Earlier versions of the documentation
-      <ul class="actions" id="earlier">
       </ul>
     </section>
 


### PR DESCRIPTION
Removes earlier versions of the documentation from the homepage, as discussed in today's developer meeting.